### PR TITLE
Fix case when `\` are used inside a string.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1985,13 +1985,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001265",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001344",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -8880,9 +8886,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001265",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw=="
+      "version": "1.0.30001344",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g=="
     },
     "chalk": {
       "version": "2.4.2",

--- a/src/addGetSettingsFunctionContent.js
+++ b/src/addGetSettingsFunctionContent.js
@@ -16,7 +16,7 @@ const getTokenPattern = require('@adobe/reactor-token-scripts-edge/src/getTokenP
 const tokenPattern = getTokenPattern();
 
 const decode = require('./decode');
-const escape = (str) => str.replace(/([\""\r\n\t])/g, '\\$1');
+const escape = (str) => str.replace(/([\""\r\n\t\\])/g, '\\$1');
 
 module.exports = (settingsString, t) => {
   var dataElementTokens = findTokensInString(`var a = ${settingsString}`)

--- a/test/fixtures/container.js
+++ b/test/fixtures/container.js
@@ -138,6 +138,9 @@ module.exports = (getDataElementValues) => ({
                   const z2 = 5 + {{core}} + 5;
                   resolve(5);
 
+                  var x1 = "\\";
+                  var x2 = '\\';
+
                   const x = getDataElementValue("core")
                   const y = "some getDataElementValue(\"core555\")";
                   const y2 = "some getDataElementValue('core556')";


### PR DESCRIPTION
Strings containing escaped backslashes were crashing the script. Example: `var a = "\\"`.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have made any necessary test changes and all tests pass.
